### PR TITLE
增加了固定当前日志文件名，滚动时再改名的小功能

### DIFF
--- a/config.go
+++ b/config.go
@@ -44,6 +44,8 @@ func SetupLogWithConf(file string) (err error) {
 	}
 
 	switch lc.Level {
+	case "trace":
+		SetLevel(TRACE)
 	case "debug":
 		SetLevel(DEBUG)
 

--- a/console_writer.go
+++ b/console_writer.go
@@ -9,6 +9,9 @@ type colorRecord Record
 
 func (r *colorRecord) String() string {
 	switch r.level {
+	case TRACE:
+		return fmt.Sprintf("\033[36m%s\033[0m [\033[34m%s\033[0m] \033[47;30m%s\033[0m %s\n",
+			r.time, LEVEL_FLAGS[r.level], r.code, r.info)
 	case DEBUG:
 		return fmt.Sprintf("\033[36m%s\033[0m [\033[34m%s\033[0m] \033[47;30m%s\033[0m %s\n",
 			r.time, LEVEL_FLAGS[r.level], r.code, r.info)

--- a/examples/file/logger.go
+++ b/examples/file/logger.go
@@ -1,0 +1,24 @@
+package logger
+
+import (
+	log4go "github.com/skoo87/log4go"
+)
+
+func GetLogger(filename string, level int) (logger *log4go.Logger) {
+	w := log4go.NewFileWriter()
+	//	filename = filename + "_%Y%M%D-%H"
+	//	w.SetPathPattern(filename)
+	pattern := "-%Y%M%D%H"
+	w.SetFileName(filename)
+	w.SetPathPattern(pattern)
+
+	logger = log4go.NewLogger()
+
+	if w == nil || logger == nil {
+		panic("Init logger failed!")
+	}
+
+	logger.Register(w)
+	logger.SetLevel(level)
+	return
+}

--- a/log.go
+++ b/log.go
@@ -1,4 +1,4 @@
-package log4go  // import skoo.me/skoo87/log4go
+package log4go
 
 import (
 	"fmt"
@@ -11,12 +11,13 @@ import (
 )
 
 var (
-	LEVEL_FLAGS = [...]string{"DEBUG", " INFO", " WARN", "ERROR", "FATAL"}
+	LEVEL_FLAGS = [...]string{"TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL"}
 	recordPool  *sync.Pool
 )
 
 const (
-	DEBUG = iota
+	TRACE = iota
+	DEBUG
 	INFO
 	WARNING
 	ERROR
@@ -33,7 +34,7 @@ type Record struct {
 }
 
 func (r *Record) String() string {
-	return fmt.Sprintf("%s [%s] <%s> %s\n", r.time, LEVEL_FLAGS[r.level], r.code, r.info)
+	return fmt.Sprintf("%s||%s||%s||%s\n", LEVEL_FLAGS[r.level], r.time, r.code, r.info)
 }
 
 type Writer interface {
@@ -91,6 +92,10 @@ func (l *Logger) SetLevel(lvl int) {
 
 func (l *Logger) SetLayout(layout string) {
 	l.layout = layout
+}
+
+func (l *Logger) Trace(fmt string, args ...interface{}) {
+	l.deliverRecordToWriter(TRACE, fmt, args...)
 }
 
 func (l *Logger) Debug(fmt string, args ...interface{}) {
@@ -236,6 +241,10 @@ func SetLevel(lvl int) {
 
 func SetLayout(layout string) {
 	logger_default.layout = layout
+}
+
+func Trace(fmt string, args ...interface{}) {
+	logger_default.deliverRecordToWriter(TRACE, fmt, args...)
 }
 
 func Debug(fmt string, args ...interface{}) {

--- a/syslog_writer.go
+++ b/syslog_writer.go
@@ -43,6 +43,8 @@ func (w *SyslogWriter) Write(r *Record) (err error) {
 	s := ((*ShortRecord)(r)).String()
 
 	switch r.level {
+	case TRACE:
+		err = w.writer.Debug(s)
 	case DEBUG:
 		err = w.writer.Debug(s)
 


### PR DESCRIPTION
HI:
   I am Zhangjunchong.
   This pull request contains two features:
   1. Add a TRACE level with the same implementation of DEBUG; (not very useful-_-)
   2. Fix the name of file which is logging the same, then rename it at rotation time. It is convenient to get information in a fixed name file rather than a varied one.